### PR TITLE
修复自定义导航栏,遮罩不能完全遮住屏幕的bug

### DIFF
--- a/IFMShare/IFMShareView.m
+++ b/IFMShare/IFMShareView.m
@@ -118,7 +118,8 @@
 
 - (void)showFromControlle:(UIViewController *)controller{
     _presentVC = controller;
-    [self showInView:controller.view];
+    //fix: 自定义导航栏,遮罩不能完全遮住屏幕
+    [self showInView:controller.view.window];
     
 }
 


### PR DESCRIPTION
感谢刚哥,贡献分享组件,在使用的过程中,首页的导航栏是自定义的,然后,分享面板不能完全显示,y值从导航栏下面开始,因为是加载VC的View上,应该加在view的window上,具体,如下图:

![](http://o9zpq25pv.bkt.clouddn.com/github/bug.png)